### PR TITLE
Allow creation of materialized views where none of the materialized columns are primary keys.

### DIFF
--- a/flask-sqlalchemy-example/materialized_view_factory.py
+++ b/flask-sqlalchemy-example/materialized_view_factory.py
@@ -33,6 +33,9 @@ def create_mat_view(name, selectable, metadata=db.metadata):
     for c in selectable.c:
         t.append_column(db.Column(c.name, c.type, primary_key=c.primary_key))
 
+    if not (any([c.primary_key for c in selectable.c])):
+        t.append_constraint(PrimaryKeyConstraint(*[c.name for c in selectable.c]))
+
     db.event.listen(
         metadata, 'after_create',
         CreateMaterializedView(name, selectable)


### PR DESCRIPTION
Basically the title. I wanted a materialized view on two columns - a non primary key column, and a derived value (`COUNT()`). 

Right now, if you have no primary keys in the columns the materialized view is derived from, the ORM barfs when creating the table because it apparently requires _every_ table-like object to have a primary key.

Anyways, when there are no primary keys in any of the available columns, create a derived primary key that includes every column in the materialized view.
